### PR TITLE
Changed the order of comparison symbols

### DIFF
--- a/satsearch/search.py
+++ b/satsearch/search.py
@@ -19,6 +19,8 @@ class SatSearchError(Exception):
 
 class Search(object):
     """ One search query (possibly multiple pages) """
+    search_op_list = ['>=', '<=', '=', '>', '<']
+    search_op_to_stac_op = {'>=': 'gte', '<=': 'lte', '=': 'eq', '>': 'gt', '<': 'lt'}
 
     def __init__(self, **kwargs):
         """ Initialize a Search object with parameters """
@@ -36,14 +38,13 @@ class Search(object):
                 kwargs['property'] = []
             kwargs['property'].append(q)
             del kwargs['collection']
-        symbols = {'>=': 'gte', '<=': 'lte', '=': 'eq', '>': 'gt', '<': 'lt'}
         if 'property' in kwargs and isinstance(kwargs['property'], list):
             queries = {}
             for prop in kwargs['property']:
-                for s in symbols:
+                for s in Search.search_op_list:
                     parts = prop.split(s)
                     if len(parts) == 2:
-                        queries = dict_merge(queries, {parts[0]: {symbols[s]: parts[1]}})
+                        queries = dict_merge(queries, {parts[0]: {Search.search_op_to_stac_op[s]: parts[1]}})
                         break
             del kwargs['property']
             kwargs['query'] = queries

--- a/satsearch/search.py
+++ b/satsearch/search.py
@@ -36,7 +36,7 @@ class Search(object):
                 kwargs['property'] = []
             kwargs['property'].append(q)
             del kwargs['collection']
-        symbols = {'=': 'eq', '>': 'gt', '<': 'lt', '>=': 'gte', '<=': 'lte'}
+        symbols = {'>=': 'gte', '<=': 'lte', '=': 'eq', '>': 'gt', '<': 'lt'}
         if 'property' in kwargs and isinstance(kwargs['property'], list):
             queries = {}
             for prop in kwargs['property']:

--- a/test/test_search.py
+++ b/test/test_search.py
@@ -89,3 +89,10 @@ class Test(unittest.TestCase):
     def test_query_bad_url(self):
         with self.assertRaises(SatSearchError):
             Search.query(url=os.path.join(config.API_URL, 'collections/nosuchcollection'))
+
+    def test_search_property_operator(self):
+        expected = {'query': {'eo:cloud_cover': {'lte': '10'}, 'collection': {'eq': 'Sentinel-2A'}}}
+        instance = Search.search(collection='Sentinel-2A',
+                                 property=['eo:cloud_cover<=10'])
+        actual = instance.kwargs
+        assert actual == expected

--- a/test/test_search.py
+++ b/test/test_search.py
@@ -91,8 +91,8 @@ class Test(unittest.TestCase):
             Search.query(url=os.path.join(config.API_URL, 'collections/nosuchcollection'))
 
     def test_search_property_operator(self):
-        expected = {'query': {'eo:cloud_cover': {'lte': '10'}, 'collection': {'eq': 'Sentinel-2A'}}}
-        instance = Search.search(collection='Sentinel-2A',
+        expected = {'query': {'eo:cloud_cover': {'lte': '10'}, 'collection': {'eq': 'sentinel-2-l1c'}}}
+        instance = Search.search(collection='sentinel-2-l1c',
                                  property=['eo:cloud_cover<=10'])
         actual = instance.kwargs
         assert actual == expected


### PR DESCRIPTION
Changed the order of symbols so that the <=, >= symbols can correctly be interpreted

Previously
```
{'eo:platform': {'eq': 'sentinel-2b'}, 'eo:cloud_cover>': {'eq': '0'}, 'eo:cloud_cover<': {'eq': '100'}, 'collection': {'eq': 'sentinel-2-l1c'}}
```

Updated
```
'eo:platform': {'eq': 'sentinel-2b'}, 'eo:cloud_cover': {'gte': '0', 'lte': '100'}, 'collection': {'eq': 'sentinel-
2-l1c'}}
```