### PR TITLE
Tweak sat-search to work with CMR-STAC

### DIFF
--- a/satsearch/search.py
+++ b/satsearch/search.py
@@ -64,6 +64,8 @@ class Search(object):
         logger.debug(f"Found results: {json.dumps(results)}")
         if 'context' in results:
             return results['context']['matched']
+        elif 'features' in results:
+            return len(results['features'])
         return 0
 
     @classmethod

--- a/satsearch/search.py
+++ b/satsearch/search.py
@@ -54,8 +54,8 @@ class Search(object):
     def found(self, headers=None):
         """ Small query to determine total number of hits """
         kwargs = {
-            'page': 1,
-            'limit': 0
+            'page_num': 1,
+            'page_size': 0
         }
         kwargs.update(self.kwargs)
         url = urljoin(self.url, 'search')
@@ -91,14 +91,14 @@ class Search(object):
             logger.warning('There are more items found (%s) than the limit (%s) provided.' % (found, limit))
         maxitems = min(found, limit)
         kwargs = {
-            'page': 1,
-            'limit': min(_limit, maxitems)
+            'page_num': 1,
+            'page_size': min(_limit, maxitems)
         }
         kwargs.update(self.kwargs)
         url = urljoin(self.url, 'search')
         while len(items) < maxitems:
             items += [Item(i) for i in self.query(url=url, headers=headers, **kwargs)['features']]
-            kwargs['page'] += 1
+            kwargs['page_num'] += 1
 
         # retrieve collections
         collections = []


### PR DESCRIPTION
# Problem

CMR-STAC had a couple of small incompatibilities with sat-search :
1. CMR-STAC uses pagination param names: `page_num`/`page_size` instead of `page`/`limit`. It would render an error response when sat-search tried to use `page` to get the next set of results.
2. CMR-STAC does not implement the context api, so it seemed like all searches returned 0 items.

# Changes

For `1`, I just changed the param names. But, obviously, this isn't an actual fix 😛 We should probably beef up the next/prev links on both the CMR-STAC side, as well as changing sat-search to use them for paging through searches.

For `2`, fall back on using the lenght of `items` returned. Not sure how this should actually work, either. I bet the easiest thing would be to either implement `context` in CMR-STAC, or update CMR-STAC to provide `numberReturned` and `numberMatches` attributes (which I think you were adding as a fall-back (possibly I just hadn't pulled those changes yet).