### PR TITLE
BUG: Check for None headers

### DIFF
--- a/satsearch/search.py
+++ b/satsearch/search.py
@@ -110,7 +110,7 @@ class Search(object):
                 _body.update({'limit': page_limit})
                 
                 if nextlink.get('merge', False):
-                    _headers.update(headers)
+                    _headers.update(headers or {})
                     _body.update(self.kwargs)
                 resp = self.query(url=nextlink['href'], headers=_headers, **_body)
             items += [Item(i) for i in resp['features']]


### PR DESCRIPTION
Headers might be `None` here, causing `dict.update(headers)` to fail.

It wasn't immediately obvious to me how to set up a test case for this, but I didn't put too much effort into understanding things.